### PR TITLE
Don't return blank when the emoji is unknow

### DIFF
--- a/lib/emoji.js
+++ b/lib/emoji.js
@@ -28,6 +28,7 @@ Emoji.prototype._get = function _get(emoji) {
   if (this.emoji.hasOwnProperty(emoji)) {
     return this.emoji[emoji];
   }
+  return ':' + emoji + ':';
 };
 
 /**

--- a/test/emoji.js
+++ b/test/emoji.js
@@ -36,6 +36,11 @@ describe("emoji.js", function () {
         should.exist(coffee);
         coffee.should.be.exactly('I ❤️  ☕️! -  😯⭐️😍  ::: test : : 👍+');
       });
+      it("should leave unknown emoji", function () {
+        var coffee = emoji.emojify('I :unknown_emoji: :star: :another_one:');
+        should.exist(coffee);
+        coffee.should.be.exactly('I :unknown_emoji: ⭐️ :another_one:');
+      });
     });
   });
 


### PR DESCRIPTION
Thanks a lot for your work !
I've just changed the behaviour when the emoji is not found, it now returns the token instead of `''` allowing it with custom emoji ;)