### PR TITLE
Check char codes instead of chars

### DIFF
--- a/lib/emoji.js
+++ b/lib/emoji.js
@@ -1,4 +1,6 @@
 /*jslint node: true*/
+require('String.prototype.codePointAt');
+
 "use strict";
 
 /**

--- a/lib/emoji.js
+++ b/lib/emoji.js
@@ -47,7 +47,7 @@ Emoji.get = function get(emoji) {
 Emoji.which = function which(emoji_code) {
   for (var prop in Emoji.emoji) {
     if (Emoji.emoji.hasOwnProperty(prop)) {
-      if (Emoji.emoji[prop] === emoji_code) {
+      if (Emoji.emoji[prop].charCodeAt() === emoji_code.charCodeAt()) {
         return prop;
       }
     }

--- a/lib/emoji.js
+++ b/lib/emoji.js
@@ -1,5 +1,5 @@
 /*jslint node: true*/
-require('String.prototype.codePointAt');
+require('string.prototype.codepointat');
 
 "use strict";
 

--- a/lib/emoji.js
+++ b/lib/emoji.js
@@ -47,7 +47,7 @@ Emoji.get = function get(emoji) {
 Emoji.which = function which(emoji_code) {
   for (var prop in Emoji.emoji) {
     if (Emoji.emoji.hasOwnProperty(prop)) {
-      if (Emoji.emoji[prop].charCodeAt() === emoji_code.charCodeAt()) {
+      if (Emoji.emoji[prop].codePointAt() === emoji_code.codePointAt()) {
         return prop;
       }
     }

--- a/package.json
+++ b/package.json
@@ -7,11 +7,24 @@
     "type": "git",
     "url": "https://github.com/omnidan/node-emoji.git"
   },
-  "keywords": ["emoji", "simple", "emoticons", "emoticon", "emojis", "smiley", "smileys", "smilies", "ideogram", "ideograms"],
+  "keywords": [
+    "emoji",
+    "simple",
+    "emoticons",
+    "emoticon",
+    "emojis",
+    "smiley",
+    "smileys",
+    "smilies",
+    "ideogram",
+    "ideograms"
+  ],
   "bugs": {
     "url": "https://github.com/omnidan/node-emoji/issues"
   },
-  "dependencies": {},
+  "dependencies": {
+    "string.prototype.codepointat": "^0.2.0"
+  },
   "devDependencies": {
     "mocha": "^2.4.5",
     "should": "^8.2.2"

--- a/test/emoji.js
+++ b/test/emoji.js
@@ -27,6 +27,11 @@ describe("emoji.js", function () {
       should.exist(coffee);
       coffee.should.be.exactly('coffee');
     });
+    it("should work for differently formed characters", function () {
+      var umbrella = emoji.which('☔');
+      should.exist(umbrella);
+      umbrella.should.be.exactly('umbrella');
+    });
   });
 
   describe("emojify(str)", function () {

--- a/test/emoji.js
+++ b/test/emoji.js
@@ -32,6 +32,13 @@ describe("emoji.js", function () {
       should.exist(umbrella);
       umbrella.should.be.exactly('umbrella');
     });
+    it("should return the same name for differently formed characters", function () {
+      var umbrella1 = emoji.which('☔');
+      should.exist(umbrella1);
+      var umbrella2 = emoji.which('☔️');
+      should.exist(umbrella2);
+      umbrella1.should.equal(umbrella2);
+    });
   });
 
   describe("emojify(str)", function () {


### PR DESCRIPTION
Ran into a weird situation where I was replacing emoji in text using a regex, and the characters didn't match (but were clearly the same emoji, with the same code point and char code). Thought it might be safer to check this way.