### PR TITLE
Flag identification bug

### DIFF
--- a/test/emoji.js
+++ b/test/emoji.js
@@ -39,6 +39,10 @@ describe("emoji.js", function () {
       should.exist(umbrella2);
       umbrella1.should.equal(umbrella2);
     });
+    it('should identify flags correctly', function () {
+      var flag_mx = emoji.which('🇲🇽');
+      flag_mx.should.equal('flag-mx')
+    })
   });
 
   describe("emojify(str)", function () {


### PR DESCRIPTION
The `emoji.which()` function does not correctly identify flags. A test is attached to reproduce the issue.
## Example

When identifying the [Flag for Mexico](http://emojipedia.org/flag-for-mexico/), the [Flag for Morocco](http://emojipedia.org/flag-for-morocco/) is returned instead.
## Cause

The root cause appears to be that the `codePointAt()` values for both flags is the same. For example:

``` js
> flag_ma = '����'
'🇲🇦'
> flag_mx = '����'
'🇲🇽'
> flag_ma.codePointAt()
127474
> flag_mx.codePointAt()
127474
```
