### PR TITLE
Fix crash if emojify string is null

### DIFF
--- a/lib/emoji.js
+++ b/lib/emoji.js
@@ -80,6 +80,8 @@ Emoji.which = function which(emoji_code) {
  * @return {string}
  */
 Emoji.emojify = function emojify(str, on_missing) {
+  if (!str) return '';
+
   return str.split(parser) // parse emoji via regex
             .map(function parseEmoji(s, i) {
               // every second element is an emoji, e.g. "test :fast_forward:" -> [ "test ", "fast_forward" ]


### PR DESCRIPTION
Prevents a crash if the `emojify` string is `null` or `undefined`. Pretty straightforward :wink: thanks!