### PR TITLE
fix: avoid polluting the Object prototype

### DIFF
--- a/lib/emoji.js
+++ b/lib/emoji.js
@@ -128,15 +128,17 @@ Emoji.search = function search(str) {
   });
 }
 
-Object.prototype.getKeyByValue = function(value) {
-  for (var prop in this) {
-    if (this.hasOwnProperty(prop)) {
-      if (this[prop] === value) {
-        return prop;
-      }  
+Object.defineProperty(Object.prototype, 'getKeyByValue', {
+  value: function(value) {
+    for (var prop in this) {
+      if (this.hasOwnProperty(prop)) {
+        if (this[prop] === value) {
+          return prop;
+        }  
+      }
     }
   }
-}
+});
 
 /**
  * unemojify a string (replace emoji with :emoji:)


### PR DESCRIPTION
This, as stands, will break all code that uses `for .. in` loops without guarding with `.hasOwnProperty(k)`. Since this mutates the global `Object.prototype` it globally affects any project with a dependency, or transitive dependency, on `node-emoji`.

`yarn`, for instance, is currently broken on fresh installs(!).