### PR TITLE
Add format argument to support wrapping of emojis

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,36 @@ emoji.random() // returns a random emoji + key, e.g. `{ emoji: '❤️', key: 'h
 emoji.search('cof') // returns an array of objects with matching emoji's. `[{ emoji: '☕️', key: 'coffee' }, { emoji: ⚰', key: 'coffin'}]`
 ```
 
+## Options
+
+### onMissing
+`emoji.emojify(str, onMissing)`;
+
+As second argument, `emojify` takes an handler to parse unknown emojis. Provide a function to add your own handler:
+
+```js
+var onMissing = function (name) {
+  return name;
+});
+
+var emojified = emoji.emojify('I :unknown_emoji: :star: :another_one:', onMissing);
+// emojified: I unknown_emoji ⭐️ another_one
+```
+
+### format
+`emoji.emojify(str, onMissing, format)`;
+
+As third argument, `emojify` takes an handler to wrap parsed emojis. Provide a function to place emojis in custom elements, and to apply your custom styling:
+
+```js
+var format = function (code, name) {
+  return '<img alt="' + code + '" src="' + name + '.png" />';
+});
+
+var emojified = emoji.emojify('I :unknown_emoji: :star: :another_one:', null, format);
+// emojified: I <img alt="❤️" src="heart.png" /> <img alt="☕️" src="coffee.png" />
+```
+
 ## Adding new emoji
 Emoji come from js-emoji (Thanks a lot :thumbsup:). You can get a JSON file with all emoji here: https://raw.githubusercontent.com/omnidan/node-emoji/master/lib/emoji.json
 

--- a/lib/emoji.js
+++ b/lib/emoji.js
@@ -77,9 +77,10 @@ Emoji.which = function which(emoji_code) {
  * emojify a string (replace :emoji: with an emoji)
  * @param  {string} str
  * @param  {function} on_missing (gets emoji name without :: and returns a proper emoji if no emoji was found)
+ * @param  {function} format (wrap the returned emoji in a custom element)
  * @return {string}
  */
-Emoji.emojify = function emojify(str, on_missing) {
+Emoji.emojify = function emojify(str, on_missing, format) {
   if (!str) return '';
 
   return str.split(parser) // parse emoji via regex
@@ -87,9 +88,15 @@ Emoji.emojify = function emojify(str, on_missing) {
               // every second element is an emoji, e.g. "test :fast_forward:" -> [ "test ", "fast_forward" ]
               if (i % 2 === 0) return s;
               var emoji = Emoji._get(s);
+
               if (emoji.indexOf(':') > -1 && typeof on_missing === 'function') {
                 return on_missing(emoji.substr(1, emoji.length-2));
               }
+
+              if (typeof format === 'function') {
+                return format(emoji, s);
+              }
+
               return emoji;
             })
             .join('') // convert back to string

--- a/test/emoji.js
+++ b/test/emoji.js
@@ -70,6 +70,15 @@ describe("emoji.js", function () {
       should.exist(coffee);
       coffee.should.be.exactly('I unknown_emoji ⭐️ another_one');
     });
+
+    it("should wrap emoji using provided cb function", function () {
+      var coffee = emoji.emojify('I :heart: :coffee:', null, function(code, name) {
+        return '<img alt="' + code + '" src="' + name + '.png" />';
+      });
+
+      should.exist(coffee);
+      coffee.should.be.exactly('I <img alt="❤️" src="heart.png" /> <img alt="☕️" src="coffee.png" />');
+    });
   });
 
   it("should return an emoji code", function () {


### PR DESCRIPTION
Closes #44

---

Relevant part of readme update:

### format
`emoji.emojify(str, onMissing, format)`;

As third argument, `emojify` takes an handler to wrap parsed emojis. Provide a function to place emojis in custom elements, and to apply your own styles:

```js
var format = function (code, name) {
  return '<img alt="' + code + '" src="' + name + '.png" />';
});

var emojified = emoji.emojify('I :unknown_emoji: :star: :another_one:', null, format);
// emojified: I <img alt="❤️" src="heart.png" /> <img alt="☕️" src="coffee.png" />
```
