### PR TITLE
Don't `format` the `missing` emojis

### DIFF
--- a/lib/emoji.js
+++ b/lib/emoji.js
@@ -89,12 +89,13 @@ Emoji.emojify = function emojify(str, on_missing, format) {
               // every second element is an emoji, e.g. "test :fast_forward:" -> [ "test ", "fast_forward" ]
               if (i % 2 === 0) return s;
               var emoji = Emoji._get(s);
+              var isMissing = emoji.indexOf(':') > -1;
 
-              if (emoji.indexOf(':') > -1 && typeof on_missing === 'function') {
+              if (isMissing && typeof on_missing === 'function') {
                 return on_missing(emoji.substr(1, emoji.length-2));
               }
 
-              if (typeof format === 'function') {
+              if (!isMissing && typeof format === 'function') {
                 return format(emoji, s);
               }
 

--- a/test/emoji.js
+++ b/test/emoji.js
@@ -71,13 +71,36 @@ describe("emoji.js", function () {
       coffee.should.be.exactly('I unknown_emoji ⭐️ another_one');
     });
 
-    it("should wrap emoji using provided cb function", function () {
+    it("should wrap emoji using provided format function", function () {
       var coffee = emoji.emojify('I :heart: :coffee:', null, function(code, name) {
         return '<img alt="' + code + '" src="' + name + '.png" />';
       });
 
       should.exist(coffee);
       coffee.should.be.exactly('I <img alt="❤️" src="heart.png" /> <img alt="☕️" src="coffee.png" />');
+    });
+
+    it("should not wrap unknown using provided format function", function () {
+      var coffee = emoji.emojify('I :unknown_emoji: :coffee:', null, function(code, name) {
+        return '<img alt="' + code + '" src="' + name + '.png" />';
+      });
+
+      should.exist(coffee);
+      coffee.should.be.exactly('I :unknown_emoji: <img alt="☕️" src="coffee.png" />');
+    });
+
+    it("should replace unknown emojis and wrap known emojis using cb functions", function () {
+      var coffee = emoji.emojify('I :unknown_emoji: :coffee:', 
+        function(name) {
+          return name;
+        }, 
+        function(code, name) {
+          return '<img alt="' + code + '" src="' + name + '.png" />';
+        }
+      );
+
+      should.exist(coffee);
+      coffee.should.be.exactly('I unknown_emoji <img alt="☕️" src="coffee.png" />');
     });
   });
 


### PR DESCRIPTION
PR #48 contained a bug where the `missing` emojis were also wrapped by the `format` callback. This behavior is unwanted, as discussed in #49.

Fixes #49 