### PR TITLE
Fix flag identification bug: `Emoji.which(🇲🇽)`

### DIFF
--- a/lib/emoji.js
+++ b/lib/emoji.js
@@ -29,6 +29,19 @@ var trim = function(str) {
   }
   return str;
 }
+
+/**
+ * Adds colons to either side
+ * of the string
+ * @param {string} str
+ * @return {string}
+ */
+var wrapColons = function(str) {
+  return (str && str.length > 0) ? ':' + str + ':' : '';
+}
+
+var NON_SPACING_MARK = String.fromCharCode(65039); // 65039 - '️' - 0xFE0F;
+
 /**
  * Emoji namespace
  */
@@ -61,17 +74,27 @@ Emoji.get = function get(emoji) {
 
 /**
  * get emoji name from code
- * @param  {string} emoji_code
+ * @param  {string} emoji
+ * @param  {boolean} includeColons should the result include the ::
  * @return {string}
  */
-Emoji.which = function which(emoji_code) {
-  for (var prop in Emoji.emoji) {
-    if (Emoji.emoji.hasOwnProperty(prop)) {
-      if (Emoji.emoji[prop].codePointAt() === emoji_code.codePointAt()) {
-        return prop;
-      }
-    }
+Emoji.which = function which(emoji_code, includeColons) {
+  var word = emojiToCode[emoji_code];
+  if (word) {
+    return includeColons ? wrapColons(word) : word;
   }
+
+  // Most of the times, the word is already returned by now. Sometimes 
+  // we need to handle the non-spacing-mark. If we haven't returned yet, 
+  // we're going to try the oposite version, with or without the mark.
+  var endsWithMark = emoji_code[emoji_code.length - 1] === NON_SPACING_MARK;
+  var alias = endsWithMark 
+    ? emoji_code.substr(0, emoji_code.length - 1) 
+    : emoji_code + NON_SPACING_MARK;
+
+  word = emojiToCode[alias];
+
+  return includeColons ? wrapColons(word) : word;
 };
 
 /**

--- a/lib/emoji.js
+++ b/lib/emoji.js
@@ -1,5 +1,4 @@
 /*jslint node: true*/
-require('string.prototype.codepointat');
 var toArray = require('lodash.toarray');
 
 "use strict";

--- a/lib/emoji.js
+++ b/lib/emoji.js
@@ -172,10 +172,6 @@ Emoji.unemojify = function unemojify(str) {
   var words = toArray(str);
 
   return words.map(function(word) {
-    var emoji_text = emojiToCode[word];
-    if (emoji_text) {
-      return ':'+emoji_text+':';
-    } 
-    return word;
+    return Emoji.which(word, true) || word;
   }).join('');
 };

--- a/lib/emoji.js
+++ b/lib/emoji.js
@@ -58,7 +58,7 @@ Emoji._get = function _get(emoji) {
   if (Emoji.emoji.hasOwnProperty(emoji)) {
     return Emoji.emoji[emoji];
   }
-  return ':' + emoji + ':';
+  return wrapColons(emoji);
 };
 
 /**

--- a/package.json
+++ b/package.json
@@ -23,8 +23,7 @@
     "url": "https://github.com/omnidan/node-emoji/issues"
   },
   "dependencies": {
-    "lodash.toarray": "^4.4.0",
-    "string.prototype.codepointat": "^0.2.0"
+    "lodash.toarray": "^4.4.0"
   },
   "devDependencies": {
     "istanbul": "^0.4.5",

--- a/test/emoji.js
+++ b/test/emoji.js
@@ -159,6 +159,12 @@ describe("emoji.js", function () {
       var coffee = emoji.unemojify('I love 👩‍❤️‍💋‍👩');
       should.exist(coffee);
       coffee.should.be.exactly('I love :woman-kiss-woman:');
-    })
+    });
+
+    it("should parse flags correctly", function () {
+      var flags = emoji.unemojify('The flags of 🇲🇽 and 🇲🇦 are not the same');
+      should.exists(flags);
+      flags.should.be.exactly('The flags of :flag-mx: and :flag-ma: are not the same');
+    });
   });
 });

--- a/test/emoji.js
+++ b/test/emoji.js
@@ -37,17 +37,32 @@ describe("emoji.js", function () {
       should.exist(coffee);
       coffee.should.be.exactly('coffee');
     });
+
     it("should work for differently formed characters", function () {
       var umbrella = emoji.which('☔');
       should.exist(umbrella);
       umbrella.should.be.exactly('umbrella');
     });
+
     it("should return the same name for differently formed characters", function () {
       var umbrella1 = emoji.which('☔');
       should.exist(umbrella1);
       var umbrella2 = emoji.which('☔️');
       should.exist(umbrella2);
       umbrella1.should.equal(umbrella2);
+    });
+
+    it("should work for flags", function() {
+      var mexico = emoji.which('🇲🇽');
+      should.exists(mexico);
+      mexico.should.be.exactly('flag-mx');
+
+      var marocco = emoji.which('🇲🇦');
+      should.exists(marocco);
+      marocco.should.be.exactly('flag-ma');
+      
+      // see issue #21
+      mexico.should.not.equal(marocco);
     });
   });
 
@@ -57,6 +72,13 @@ describe("emoji.js", function () {
       should.exist(coffee);
       coffee.should.be.exactly('I ❤️  ☕️! -  😯⭐️😍  ::: test : : 👍+');
     });
+
+    it("should handle flags correctly", function() {
+      var flags = emoji.emojify('Mexico :flag-mx: and Marocco :flag-ma: are not the same');
+      should.exists(flags);
+      flags.should.be.exactly('Mexico 🇲🇽 and Marocco 🇲🇦 are not the same');
+    });
+
     it("should leave unknown emoji", function () {
       var coffee = emoji.emojify('I :unknown_emoji: :star: :another_one:');
       should.exist(coffee);


### PR DESCRIPTION
Fix the flag issue from PR #21 

---
This test now turns green.

```js
    it("should work for flags", function() {
      var mexico = emoji.which('🇲🇽');
      should.exists(mexico);
      mexico.should.be.exactly('flag-mx');

      var marocco = emoji.which('🇲🇦');
      should.exists(marocco);
      marocco.should.be.exactly('flag-ma');
      
      // see issue #21
      mexico.should.not.equal(marocco);
    });
```