### PR TITLE
Feature/emoji-hasEmoji

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ emoji.emojify('I :heart: :coffee:!') // replaces all :emoji: with the actual emo
 emoji.random() // returns a random emoji + key, e.g. `{ emoji: '❤️', key: 'heart' }`
 emoji.search('cof') // returns an array of objects with matching emoji's. `[{ emoji: '☕️', key: 'coffee' }, { emoji: ⚰', key: 'coffin'}]`
 emoji.unemojify('I ❤️ 🍕') // replaces the actual emoji with :emoji:, in this case: returns "I :heart: :pizza:"
+emoji.find('🍕'); // Find the `pizza` emoji, and returns `({ emoji: '🍕', key: 'pizza' })`;
+emoji.find('pizza'); // Find the `pizza` emoji, and returns `({ emoji: '🍕', key: 'pizza' })`;
 ```
 
 ## Options

--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ emoji.search('cof') // returns an array of objects with matching emoji's. `[{ em
 emoji.unemojify('I ❤️ 🍕') // replaces the actual emoji with :emoji:, in this case: returns "I :heart: :pizza:"
 emoji.find('🍕'); // Find the `pizza` emoji, and returns `({ emoji: '🍕', key: 'pizza' })`;
 emoji.find('pizza'); // Find the `pizza` emoji, and returns `({ emoji: '🍕', key: 'pizza' })`;
+emoji.hasEmoji('🍕'); // Validate if this library knows an emoji like `🍕`
+emoji.hasEmoji('pizza'); // Validate if this library knowns a emoji with the name `pizza`
 ```
 
 ## Options

--- a/lib/emoji.js
+++ b/lib/emoji.js
@@ -109,22 +109,8 @@ Emoji.get = function get(emoji) {
  * @return {string}
  */
 Emoji.which = function which(emoji_code, includeColons) {
-  emoji_code = stripNSB(emoji_code);
-  
-  var word = emojiByCode[emoji_code];
-  if (word) {
-    return includeColons ? wrapColons(word) : word;
-  }
-
-  // Most of the times, the word is already returned by now. Sometimes 
-  // we need to handle the non-spacing-mark. If we haven't returned yet, 
-  // we're going to try the oposite version, with or without the mark.
-  var endsWithMark = emoji_code[emoji_code.length - 1] === NON_SPACING_MARK;
-  var alias = endsWithMark 
-    ? emoji_code.substr(0, emoji_code.length - 1) 
-    : emoji_code + NON_SPACING_MARK;
-
-  word = emojiByCode[alias];
+  var code = stripNSB(emoji_code); 
+  var word = emojiByCode[code]; 
 
   return includeColons ? wrapColons(word) : word;
 };

--- a/lib/emoji.js
+++ b/lib/emoji.js
@@ -1,5 +1,6 @@
 /*jslint node: true*/
 var toArray = require('lodash.toarray');
+var emoji = require('./emoji.json');
 
 "use strict";
 
@@ -54,8 +55,8 @@ var NON_SPACING_MARK = String.fromCharCode(65039); // 65039 - '️' - 0xFE0F;
 /**
  * Emoji namespace
  */
-var Emoji = module.exports = {
-  emoji: require('./emoji.json')
+var Emoji = {
+  emoji: emoji,
 };
 
 /**
@@ -185,3 +186,5 @@ Emoji.unemojify = function unemojify(str) {
     return Emoji.which(word, true) || word;
   }).join('');
 };
+
+module.exports = Emoji;

--- a/lib/emoji.js
+++ b/lib/emoji.js
@@ -89,7 +89,7 @@ Emoji._get = function _get(emoji) {
     return emojiByName[emoji];
   }
 
-  return wrapColons(emoji);
+  return ensureColons(emoji);
 };
 
 /**

--- a/lib/emoji.js
+++ b/lib/emoji.js
@@ -1,6 +1,6 @@
 /*jslint node: true*/
 var toArray = require('lodash.toarray');
-var emoji = require('./emoji.json');
+var emojiByName = require('./emoji.json');
 
 "use strict";
 
@@ -50,13 +50,32 @@ var ensureColons = function(str) {
   return (typeof str === 'string' && str[0] !== ':') ? wrapColons(str) : str;
 }
 
+// Non spacing mark, some emoticons have them. It's the 'Variant Form', 
+// which provides more information so that emoticons can be rendered as 
+// more colorful graphics. FE0E is a unicode text version, where as FE0F 
+// should be rendered as a graphical version. The code gracefully degrades.
 var NON_SPACING_MARK = String.fromCharCode(65039); // 65039 - '️' - 0xFE0F;
+var nonSpacingRegex = new RegExp(NON_SPACING_MARK, 'g') 
+
+// Remove the non-spacing-mark from the code, never send a stripped version
+// to the client, as it kills graphical emoticons.
+var stripNSB = function(code) {
+  return code.replace(nonSpacingRegex, '');
+};
+
+// Reversed hash table, where as emojiByName contains a { heart: '❤' } 
+// dictionary emojiByCode contains { ❤: 'heart' }. The codes are normalized 
+// to the text version.
+var emojiByCode = Object.keys(emojiByName).reduce(function(h,k) {
+  h[stripNSB(emojiByName[k])] = k;
+  return h;
+}, {});
 
 /**
  * Emoji namespace
  */
 var Emoji = {
-  emoji: emoji,
+  emoji: emojiByName,
 };
 
 /**
@@ -65,9 +84,10 @@ var Emoji = {
  * @return {string}
  */
 Emoji._get = function _get(emoji) {
-  if (Emoji.emoji.hasOwnProperty(emoji)) {
-    return Emoji.emoji[emoji];
+  if (emojiByName.hasOwnProperty(emoji)) {
+    return emojiByName[emoji];
   }
+
   return wrapColons(emoji);
 };
 
@@ -89,7 +109,9 @@ Emoji.get = function get(emoji) {
  * @return {string}
  */
 Emoji.which = function which(emoji_code, includeColons) {
-  var word = emojiToCode[emoji_code];
+  emoji_code = stripNSB(emoji_code);
+  
+  var word = emojiByCode[emoji_code];
   if (word) {
     return includeColons ? wrapColons(word) : word;
   }
@@ -102,7 +124,7 @@ Emoji.which = function which(emoji_code, includeColons) {
     ? emoji_code.substr(0, emoji_code.length - 1) 
     : emoji_code + NON_SPACING_MARK;
 
-  word = emojiToCode[alias];
+  word = emojiByCode[alias];
 
   return includeColons ? wrapColons(word) : word;
 };
@@ -143,11 +165,11 @@ Emoji.emojify = function emojify(str, on_missing, format) {
  * @return {string}
  */
 Emoji.random = function random() {
-  var emojiKeys = Object.keys(Emoji.emoji);
+  var emojiKeys = Object.keys(emojiByName);
   var randomIndex = Math.floor(Math.random() * emojiKeys.length);
   var key = emojiKeys[randomIndex];
   var emoji = Emoji._get(key);
-  return {key: key, emoji: emoji};
+  return { key: key, emoji: emoji };
 }
 
 /**
@@ -156,7 +178,7 @@ Emoji.random = function random() {
  *  @return {Array.<Object>}
  */
 Emoji.search = function search(str) {
-  var emojiKeys = Object.keys(Emoji.emoji);
+  var emojiKeys = Object.keys(emojiByName);
   var matcher = trim(str)
   var matchingKeys = emojiKeys.filter(function(key) {
     return key.toString().indexOf(matcher) === 0;
@@ -168,10 +190,6 @@ Emoji.search = function search(str) {
     };
   });
 }
-
-var emojiToCode = Object.keys(Emoji.emoji).reduce(function(h,k) {
-  return h[Emoji.emoji[k]] = k, h;
-}, {});
 
 /**
  * unemojify a string (replace emoji with :emoji:)

--- a/lib/emoji.js
+++ b/lib/emoji.js
@@ -7,7 +7,7 @@ var emojiByName = require('./emoji.json');
 /**
  * regex to parse emoji in a string - finds emoji, e.g. :coffee:
  */
-var parser = /:([a-zA-Z0-9_\-\+]+):/g;
+var emojiNameRegex = /:([a-zA-Z0-9_\-\+]+):/g;
 
 /**
  * Removes colons on either side
@@ -126,7 +126,7 @@ Emoji.which = function which(emoji_code, includeColons) {
 Emoji.emojify = function emojify(str, on_missing, format) {
   if (!str) return '';
 
-  return str.split(parser) // parse emoji via regex
+  return str.split(emojiNameRegex) // parse emoji via regex
             .map(function parseEmoji(s, i) {
               // every second element is an emoji, e.g. "test :fast_forward:" -> [ "test ", "fast_forward" ]
               if (i % 2 === 0) return s;

--- a/lib/emoji.js
+++ b/lib/emoji.js
@@ -36,7 +36,17 @@ var trim = function(str) {
  * @return {string}
  */
 var wrapColons = function(str) {
-  return (str && str.length > 0) ? ':' + str + ':' : '';
+  return (typeof str === 'string' && str.length > 0) ? ':' + str + ':' : str;
+}
+
+/**
+ * Ensure that the word is wrapped in colons
+ * by only adding them, if they are not there.
+ * @param {string} str
+ * @return {string}
+ */
+var ensureColons = function(str) {
+  return (typeof str === 'string' && str[0] !== ':') ? wrapColons(str) : str;
 }
 
 var NON_SPACING_MARK = String.fromCharCode(65039); // 65039 - '️' - 0xFE0F;

--- a/lib/emoji.js
+++ b/lib/emoji.js
@@ -104,6 +104,40 @@ Emoji.get = function get(emoji) {
 };
 
 /**
+ * find the emoji by either code or name
+ * @param {string} nameOrCode The emoji to find, either `coffee`, `:coffee:` or `☕`;
+ * @return {object}
+ */
+Emoji.find = function get(nameOrCode) {
+  return Emoji.findByName(nameOrCode) || Emoji.findByCode(nameOrCode);
+};
+
+/**
+ * find the emoji by name
+ * @param {string} name The emoji to find either `coffee` or `:coffee:`;
+ * @return {object}
+ */
+Emoji.findByName = function get(name) {
+  var stripped = stripColons(name);
+  var emoji = emojiByName[stripped];
+
+  return emoji ? ({ emoji: emoji, key: stripped }) : undefined;
+};
+
+/**
+ * find the emoji by code (emoji)
+ * @param {string} code The emoji to find; for example `☕` or `☔`
+ * @return {object}
+ */
+Emoji.findByCode = function get(code) {
+  var stripped = stripNSB(code);
+  var name = emojiByCode[stripped];
+
+  // lookup emoji to ensure the Variant Form is returned
+  return name ? ({ emoji: emojiByName[name], key: name }) : undefined;
+};
+
+/**
  * get emoji name from code
  * @param  {string} emoji
  * @param  {boolean} includeColons should the result include the ::

--- a/lib/emoji.js
+++ b/lib/emoji.js
@@ -137,6 +137,36 @@ Emoji.findByCode = function get(code) {
   return name ? ({ emoji: emojiByName[name], key: name }) : undefined;
 };
 
+
+/**
+ * Check if an emoji is known by this library
+ * @param {string} nameOrCode The emoji to validate, either `coffee`, `:coffee:` or `☕`;
+ * @return {object}
+ */
+Emoji.hasEmoji = function get(nameOrCode) {
+  return Emoji.hasEmojiByName(nameOrCode) || Emoji.hasEmojiByCode(nameOrCode);
+};
+
+/**
+ * Check if an emoji with given name is known by this library
+ * @param {string} name The emoji to validate either `coffee` or `:coffee:`;
+ * @return {object}
+ */
+Emoji.hasEmojiByName = function get(name) {
+  var result = Emoji.findByName(name);
+  return !!result && result.key === stripColons(name);
+};
+
+/**
+ * Check if a given emoji is known by this library
+ * @param {string} code The emoji to validate; for example `☕` or `☔`
+ * @return {object}
+ */
+Emoji.hasEmojiByCode = function get(code) {
+  var result = Emoji.findByCode(code);
+  return !!result && stripNSB(result.emoji) === stripNSB(code);
+};
+
 /**
  * get emoji name from code
  * @param  {string} emoji

--- a/lib/emoji.js
+++ b/lib/emoji.js
@@ -15,18 +15,19 @@ var parser = /:([a-zA-Z0-9_\-\+]+):/g;
  * @param  {string} str
  * @return {string}
  */
-var trim = function(str) {
+var stripColons = function(str) {
   var colonIndex = str.indexOf(':');
   if (colonIndex > -1) {
     // :emoji: (http://www.emoji-cheat-sheet.com/)
     if (colonIndex === str.length - 1) {
       str = str.substring(0, colonIndex);
-      return trim(str);
+      return stripColons(str);
     } else {
       str = str.substr(colonIndex + 1);
-      return trim(str);
+      return stripColons(str);
     }
   }
+
   return str;
 }
 
@@ -97,7 +98,7 @@ Emoji._get = function _get(emoji) {
  * @return {string}
  */
 Emoji.get = function get(emoji) {
-  emoji = trim(emoji);
+  emoji = stripColons(emoji);
 
   return Emoji._get(emoji);
 };
@@ -165,7 +166,7 @@ Emoji.random = function random() {
  */
 Emoji.search = function search(str) {
   var emojiKeys = Object.keys(emojiByName);
-  var matcher = trim(str)
+  var matcher = stripColons(str)
   var matchingKeys = emojiKeys.filter(function(key) {
     return key.toString().indexOf(matcher) === 0;
   });

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "coverage": "./node_modules/.bin/istanbul cover _mocha test",
     "emojiparse": "node lib/emojiparse.js",
     "test": "./node_modules/.bin/mocha --require should --bail --reporter spec test/*",
+    "watch": "./node_modules/.bin/mocha --require should --bail --reporter spec test/* --watch",
     "prepublish": "npm run test"
   },
   "main": "index.js",

--- a/test/emoji.js
+++ b/test/emoji.js
@@ -190,4 +190,29 @@ describe("emoji.js", function () {
       flags.should.be.exactly('The flags of :flag-mx: and :flag-ma: are not the same');
     });
   });
+
+  describe('find emoji', function() {
+    it('Should be able to find a emoji by :name:', function() {
+      var result = emoji.find(':heart:')
+      should.exists(result);
+      result.should.eql({ emoji: '❤️', key: 'heart' });
+    });
+
+    it('Should be able to find an emoji by name', function() {
+      var result = emoji.find('heart');
+      should.exists(result);
+      result.should.eql({ emoji: '❤️', key: 'heart' });
+    });
+
+    it('Should be able to find an emoji by code', function() {
+      var result = emoji.find('❤');
+      should.exists(result);
+      result.should.eql({ emoji: '❤️', key: 'heart' });
+    });
+
+    it('Should return `undefined` for unknown emojis', function() {
+      var result = emoji.find('unknown_emoji');
+      should.not.exists(result);
+    })
+  });
 });

--- a/test/emoji.js
+++ b/test/emoji.js
@@ -215,4 +215,36 @@ describe("emoji.js", function () {
       should.not.exists(result);
     })
   });
+
+  describe('hasEmoji', function() {
+    it('Should be able to check a emoji by :name:', function() {
+      var result = emoji.hasEmoji(':heart:');
+      result.should.equal(true)
+    });
+
+    it('Should be able to check a emoji by name', function() {
+      var result = emoji.hasEmoji('heart');
+      result.should.equal(true);
+    });
+
+    it('Should be able to check a emoji by code text form)', function() {
+      var result = emoji.hasEmoji('❤');
+      result.should.equal(true);
+    });
+
+    it('Should be able to check a emoji by code in variant form', function() {
+      var result = emoji.hasEmoji('❤️');
+      result.should.equal(true);
+    });
+
+    it('Should return false for unknown emoji names', function() {
+      var result = emoji.hasEmoji(':pizza-kiss-coffee:');
+      result.should.equal(false);
+    });
+
+    it('Should return false for unknown emoji codes', function() {
+      var result = emoji.hasEmoji('🍕❤️‍💋‍☕');
+      result.should.equal(false);
+    });
+  });
 });


### PR DESCRIPTION
Add `Emoji.hasEmoji` method. This PR is build upon #53, so either that one should be merged first, or this one should be refactored.

Readme should also cover `Emoji.hasEmojiByName ` and `Emoji.hasEmojiByCode`, but like I wrote in #53, I think the readme could use a general makeover. So I wanted to postpone that change, to keep the upcoming release more agile. `Emoji.hasEmoji` is covered by the readme update.

This PR turnes the tests below green:

```js
describe('hasEmoji', function() {

    it('Should be able to check a emoji by :name:', function() {
      var result = emoji.hasEmoji(':heart:');
      result.should.equal(true)
    });

    it('Should be able to check a emoji by name', function() {
      var result = emoji.hasEmoji('heart');
      result.should.equal(true);
    });

    it('Should be able to check a emoji by code text form)', function() {
      var result = emoji.hasEmoji('❤');
      result.should.equal(true);
    });

    it('Should be able to check a emoji by code in variant form', function() {
      var result = emoji.hasEmoji('❤️');
      result.should.equal(true);
    });

    it('Should return false for unknown emoji names', function() {
      var result = emoji.hasEmoji(':pizza-kiss-coffee:');
      result.should.equal(false);
    });

    it('Should return false for unknown emoji codes', function() {
      var result = emoji.hasEmoji('🍕❤️‍💋‍☕');
      result.should.equal(false);
    });

  });
```

