### PR TITLE
Feature/emoji strip

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ emoji.find('🍕'); // Find the `pizza` emoji, and returns `({ emoji: '🍕', ke
 emoji.find('pizza'); // Find the `pizza` emoji, and returns `({ emoji: '🍕', key: 'pizza' })`;
 emoji.hasEmoji('🍕'); // Validate if this library knows an emoji like `🍕`
 emoji.hasEmoji('pizza'); // Validate if this library knowns a emoji with the name `pizza`
+emoji.strip('⚠️ 〰️ 〰️ low disk space'); // Strips the string from emoji's, in this case returns: "low disk space".
+emoji.replace('⚠️ 〰️ 〰️ low disk space', (emoji) => `${emoji.key}:`); // Replace emoji's by callback method: "warning: low disk space"
 ```
 
 ## Options

--- a/lib/emoji.js
+++ b/lib/emoji.js
@@ -10,6 +10,12 @@ var emojiByName = require('./emoji.json');
 var emojiNameRegex = /:([a-zA-Z0-9_\-\+]+):/g;
 
 /**
+ * regex to trim whitespace
+ * use instead of String.prototype.trim() for IE8 supprt
+ */
+var trimSpaceRegex = /^[\s\uFEFF\xA0]+|[\s\uFEFF\xA0]+$/g;
+
+/**
  * Removes colons on either side
  * of the string if present
  * @param  {string} str
@@ -254,6 +260,42 @@ Emoji.unemojify = function unemojify (str) {
   return words.map(function(word) {
     return Emoji.which(word, true) || word;
   }).join('');
+};
+
+/**
+ * replace emojis with replacement value
+ * @param {string} str
+ * @param {function|string} the string or callback function to replace the emoji with
+ * @param {boolean} should trailing whitespaces be cleaned? Defaults false
+ * @return {string}
+ */
+Emoji.replace = function replace (str, replacement, cleanSpaces) {
+  if (!str) return '';
+
+  var replace = typeof replacement === 'function' ? replacement : function() { return replacement; };
+  var words = toArray(str);
+
+  var replaced = words.map(function(word, idx) {
+    var emoji = Emoji.findByCode(word);
+    
+    if (emoji && cleanSpaces && words[idx + 1] === ' ') {
+      words[idx + 1] = '';
+    }
+
+    return emoji ? replace(emoji) : word;
+  }).join('');
+
+  return cleanSpaces ? replaced.replace(trimSpaceRegex, '') : replaced;
+};
+
+
+/**
+ * remove all emojis from a string
+ * @param {string} str
+ * @return {string}
+ */
+Emoji.strip = function strip (str) {
+  return Emoji.replace(str, '', true);
 };
 
 module.exports = Emoji;

--- a/lib/emoji.js
+++ b/lib/emoji.js
@@ -198,7 +198,7 @@ Emoji.emojify = function emojify (str, on_missing, format) {
               var isMissing = emoji.indexOf(':') > -1;
 
               if (isMissing && typeof on_missing === 'function') {
-                return on_missing(emoji.substr(1, emoji.length-2));
+                return on_missing(s);
               }
 
               if (!isMissing && typeof format === 'function') {

--- a/test/emoji.js
+++ b/test/emoji.js
@@ -247,4 +247,55 @@ describe("emoji.js", function () {
       result.should.equal(false);
     });
   });
+
+  describe('replace', function() {
+    it('Should be able to strip emojis', function() {
+      var result = emoji.replace('Host: eseaps001 Addr: 10.XX.XX.XX: - ⚠️ 〰️ 〰️ low disk space', '', true);
+      result.should.equal('Host: eseaps001 Addr: 10.XX.XX.XX: - low disk space');
+    });
+
+    it('Should keep the trailing spaces when not explicitly told to clean', function() {
+      var result = emoji.replace('Host: eseaps001 Addr: 10.XX.XX.XX: - ⚠️ 〰️ 〰️ low disk space', '');
+      result.should.equal('Host: eseaps001 Addr: 10.XX.XX.XX: -    low disk space');
+    });
+
+    it('Should be able to strip a emoji by code text form', function() {
+      var result = emoji.replace('I ❤ coffee', '', true);
+      result.should.equal('I coffee');
+    });
+
+    it('Should be able to strip a emoji by code in variant form', function() {
+      var result = emoji.replace('I ❤️ cleaning', '', true);
+      result.should.equal('I cleaning');
+    });
+
+    it('Should be able to strip complex emojis', function() {
+      var result = emoji.replace('Where did this 👩‍❤️‍💋‍👩 happen?', '', true);
+      result.should.equal('Where did this happen?');
+    });
+
+    it('Should be able to strip flag emojis', function() {
+      var result = emoji.replace('There is no flag 🇲🇽', '', true);
+      result.should.equal('There is no flag');
+    });
+
+    it('Should be able to replace by callback function', function() {
+      var result = emoji.replace('There is no ⚠ on my hard drive', function (emoji) { 
+        return emoji.key;
+      });
+      result.should.equal('There is no warning on my hard drive');
+    });
+
+    it('Non existing complex emojis are known to be ignored', function() {
+      var result = emoji.replace('Some 🍕❤️‍💋‍☕ emoji', '');
+      result.should.not.equal('Some emoji');
+    });
+  });
+
+  describe('strip', function() {
+    it('Should be able to strip emojis', function() {
+      var result = emoji.strip('Host: eseaps001 Addr: 10.XX.XX.XX: - ⚠️ 〰️ 〰️ low disk space');
+      result.should.equal('Host: eseaps001 Addr: 10.XX.XX.XX: - low disk space');
+    });
+  });
 });


### PR DESCRIPTION
Closes #17 

The following functionality is added:

### `Emoji.replace`

```js
emoji.replace('Where did this 👩‍❤️‍💋‍👩 happen?', '', true);
// » Where did this happen?

emoji.replace('There is no ⚠ on my hard drive', x => x.key);
// » There is no warning on my hard drive
```

And some things can't be done; as discussed in #17 
```js
// this ain't 3 emoji's, it's an unsupported complex emoji
emoji.replace('Some 🍕❤️‍💋‍☕ emoji', ''); 
// » Some 🍕❤️‍💋‍☕ emoji');
```

### `Emoji.strip` 
`Emoji.strip` is a shortcut for `replace(str, '', true);`

```js
emoji.strip('Host: eseaps001 Addr: 10.XX.XX.XX: - ⚠️ 〰️ 〰️ low disk space');
// » Host: eseaps001 Addr: 10.XX.XX.XX: - low disk space
```