### PR TITLE
allow search to return all entries that contain searched text

### DIFF
--- a/lib/emoji.js
+++ b/lib/emoji.js
@@ -238,7 +238,7 @@ Emoji.search = function search (str) {
   var emojiKeys = Object.keys(emojiByName);
   var matcher = stripColons(str)
   var matchingKeys = emojiKeys.filter(function(key) {
-    return key.toString().indexOf(matcher) === 0;
+    return key.toString().indexOf(matcher) >= 0;
   });
   return matchingKeys.map(function(key) {
     return {


### PR DESCRIPTION
in some cases, one may not know the exact name/prefix of the emoji, but know an infix instead. For example, I might want to search for the `:new_moon` emoji, but only remember that it contains `moon`.