### PR TITLE
update get() to handle emoji code arguments so they arent wrapped in …

### DIFF
--- a/lib/emoji.js
+++ b/lib/emoji.js
@@ -86,12 +86,14 @@ var Emoji = {
 };
 
 /**
- * get emoji code from name
+ * get emoji code from name. return emoji code back if code is passed in.
  * @param  {string} emoji
  * @return {string}
  */
 Emoji._get = function _get (emoji) {
-  if (emojiByName.hasOwnProperty(emoji)) {
+  if (emojiByCode[stripNSB(emoji)]) {
+    return emoji;
+  } else if (emojiByName.hasOwnProperty(emoji)) {
     return emojiByName[emoji];
   }
 
@@ -277,7 +279,7 @@ Emoji.replace = function replace (str, replacement, cleanSpaces) {
 
   var replaced = words.map(function(word, idx) {
     var emoji = Emoji.findByCode(word);
-    
+
     if (emoji && cleanSpaces && words[idx + 1] === ' ') {
       words[idx + 1] = '';
     }

--- a/test/emoji.js
+++ b/test/emoji.js
@@ -8,11 +8,17 @@ var emoji = require('../index');
 
 describe("emoji.js", function () {
   describe("get(emoji)", function () {
-    it("should return an emoji code", function () {
+    it("should return an emoji code when passed a string", function () {
       var coffee = emoji.get('coffee');
       should.exist(coffee);
       coffee.should.be.exactly('☕');
     });
+
+    it("should return emoji code back when passed an emoji code", function () {
+      var dancers = emoji.get('👯‍♀️');
+      should.exist(dancers);
+      dancers.should.be.exactly('👯‍♀️');
+    })
 
     it("should support github flavored markdown emoji", function () {
       var coffee = emoji.get(':coffee:');


### PR DESCRIPTION
…colons

This PR addresses issue #76 .

When passed an emoji code, `get()` returned the emoji code wrapped in colons.  This code modifies `get()` so that if it is passed an emoji code argument, it simply returns the emoji code back.  It still functions the same as before when passed an emoji name.

I also added a test for this functionality.