### PR TITLE
Fix unemojify and replace

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,7 +23,7 @@ function replace (string, replacement, { removeSpaces = false } = {}) {
 
   const replaceFn = typeof replacement === 'function' ? replacement : () => replacement
 
-  const chars = string.split('')
+  const chars = [...string]
 
   return chars
     .map((char, i) => {
@@ -123,8 +123,7 @@ const core = {
   unemojify (string) {
     ow(string, ow.string)
 
-    return string
-      .split('')
+    return [...string]
       .map(char => core.which(char, { markdown: true }) || char)
       .join('')
   }

--- a/test.js
+++ b/test.js
@@ -26,7 +26,7 @@ test('random', t => {
 
 test('replace', t => {
   t.is(emoji.replace('a ☕ c', 'b'), 'a b c')
-  t.is(emoji.replace('a ☕ c', () => 'b'), 'a b c')
+  t.is(emoji.replace('a 🌭 c', () => 'b'), 'a b c')
 })
 
 test('strip', t => {
@@ -41,6 +41,7 @@ test('emojify', t => {
 
 test('unemojify', t => {
   t.is(emoji.unemojify('a ☕ c'), 'a :hot beverage: c')
+  t.is(emoji.unemojify('a ☕ 🌭 c'), 'a :hot beverage: :hot dog: c')
 })
 
 test('search', t => {


### PR DESCRIPTION
The `unemojify` and `replace` methods are broken on v2 because JavaScript's native `String.split` doesn't properly handle UTF-16 surrogate pairs. 

* Replaced the `string.split('')` calls in `index.js` with `[...string]` which does properly parse surrogate pairs
* Added a two new assertions which would fail until the old code