### PR TITLE
more robust search

### DIFF
--- a/lib/emoji.js
+++ b/lib/emoji.js
@@ -16,6 +16,20 @@ var emojiNameRegex = /:([a-zA-Z0-9_\-\+]+):/g;
 var trimSpaceRegex = /^[\s\uFEFF\xA0]+|[\s\uFEFF\xA0]+$/g;
 
 /**
+ * If search term is plural
+ * remove the s to search
+ * @param {string} str
+ * @return {string}
+*/
+function unplural (str) {
+  if (str[str.length - 1] === 's') {
+    return str.substring(0, str.length - 1);
+  } else {
+    return str;
+  }
+}
+
+/**
  * Removes colons on either side
  * of the string if present
  * @param  {string} str
@@ -238,10 +252,19 @@ Emoji.random = function random () {
  */
 Emoji.search = function search (str) {
   var emojiKeys = Object.keys(emojiByName);
-  var matcher = stripColons(str)
+  var matcher = unplural(stripColons(str));
   var matchingKeys = emojiKeys.filter(function(key) {
-    return key.toString().indexOf(matcher) === 0;
+    let splits = key.toString().split('');
+    for (let i = 0; i < splits.length; i++) {
+      let item = splits.slice(i, i + str.length).join('');
+      if (matcher === item) {
+        return key.toString();
+      } else {
+        continue;
+      }
+    }
   });
+
   return matchingKeys.map(function(key) {
     return {
       key: key,


### PR DESCRIPTION
Search is now more robust displaying results based on matches found anywhere in the emoji name.

**Previously:** Searching for tree would return "[ ]" because for example "evergreen_tree" begins with ever, not tree. Now looking at each section of n numbers (n begin the length of the search string) of the name it can be found. 

**Now:** "evergreen_tree" will decide if "ever" matches the search, " verg", "ergr", etc. until "tree" and it will return:
[
  { key: 'evergreen_tree', emoji: '🌲' },
  { key: 'deciduous_tree', emoji: '🌳' },
  { key: 'palm_tree', emoji: '🌴' },
  { key: 'christmas_tree', emoji: '🎄' },
  { key: 'tanabata_tree', emoji: '🎋' }
]

_Also removes the "s" at the end of strings allowing for plural searches to return the emoji in question based on the singular emoji name._