### PR TITLE
feat: update emojilib to v3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,17 @@
 {
   "name": "node-emoji",
-  "version": "2.0.0",
+  "version": "2.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "node-emoji",
-      "version": "2.0.0",
+      "version": "2.0.2",
       "license": "MIT",
       "dependencies": {
         "@sindresorhus/is": "^5.3.0",
         "char-regex": "^2.0.1",
-        "emojilib": "^2.4.0",
+        "emojilib": "^3.0.10",
         "skin-tone": "^3.0.0",
         "tsup": "^6.7.0"
       },
@@ -1691,9 +1691,9 @@
       "dev": true
     },
     "node_modules/emojilib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/emojilib/-/emojilib-2.4.0.tgz",
-      "integrity": "sha512-5U0rVMU5Y2n2+ykNLQqMoqklN9ICBT/KsvC1Gz6vqHbz2AXXGkG+Pm5rMWk/8Vjrr/mY9985Hi8DYzn1F09Nyw=="
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/emojilib/-/emojilib-3.0.10.tgz",
+      "integrity": "sha512-VQtCRroFykPTJaoEBEGFg5tI+rEluabjuaVDDbSftDtiRJ5GuqRG/LGV1mmDzkJP4bh5rzuEBOafMN68/YXQcQ=="
     },
     "node_modules/error-ex": {
       "version": "1.3.2",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "@sindresorhus/is": "^5.3.0",
     "char-regex": "^2.0.1",
-    "emojilib": "^2.4.0",
+    "emojilib": "^3.0.10",
     "skin-tone": "^3.0.0",
     "tsup": "^6.7.0"
   },

--- a/src/data.js
+++ b/src/data.js
@@ -2,9 +2,30 @@ import emojilib from 'emojilib'
 
 import { normalizeCode } from './utils.js'
 
-export const emojiData = Object.entries(emojilib.lib).map(
-  ([name, { char: emoji }]) => [name, emoji]
-)
+export const emojiData = [
+  // First we fill in all possible names for each emoji
+  ...Object.entries(emojilib).flatMap(([emoji, names]) => {
+    return names.map(name => [name, emoji])
+  }),
+  // Then we give priority to the first name for each emoji
+  ...Object.entries(emojilib).flatMap(([emoji, [name]]) => {
+    const results = [[name, emoji]]
+
+    if (name.startsWith('flag_')) {
+      results.push([name.slice('flag_'.length), emoji])
+    }
+
+    if (name.startsWith('smiling_face_with_')) {
+      results.push([name.slice('smiling_face_with_'.length), emoji])
+    }
+
+    if (name.endsWith('_face')) {
+      results.push([name.slice(0, name.length - '_face'.length), emoji])
+    }
+
+    return results
+  }),
+]
 
 export const emojiCodesByName = new Map(emojiData)
 

--- a/src/emojify.test.js
+++ b/src/emojify.test.js
@@ -38,9 +38,9 @@ describe('emojify', () => {
   it('parses multiple :emoji: in a string when there are multiple emoji', () => {
     expect(
       emojify(
-        'I :heart:  :coffee:! -  :hushed::star::heart_eyes:  ::: test : : :+1:+'
+        'I :beating_heart:  :coffee:! -  :hushed::star::heart_eyes:  ::: test : : :+1:+'
       )
-    ).toBe('I ❤️  ☕! -  😯⭐😍  ::: test : : 👍+')
+    ).toBe('I 💓  ☕! -  😯⭐😍  ::: test : : 👍+')
   })
 
   it('formats emoji when given a format function', () => {
@@ -49,5 +49,9 @@ describe('emojify', () => {
         format: name => `[${name}]`,
       })
     ).toBe('I [:unknown_emoji:] [⭐] [:another_one:]')
+  })
+
+  it('includes emojis added in emojilib v3', () => {
+    expect(emojify(':airplane_departure: and :flashlight:')).toBe('🛫 and 🔦')
   })
 })


### PR DESCRIPTION
Bumps [emojilib](https://www.npmjs.com/package/emojilib) from the older v2 version we're on to its latest v3.

Note that this contains quite a few changes in how emojis are listed. See https://github.com/omnidan/node-emoji/pull/132/files#r1197993734

Fixes #129. Fixes #131.