### PR TITLE
chore: export typescript type definitions

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "typescript": "^5.0.4"
   },
   "scripts": {
-    "build": "tsup ./src/index.ts --format esm,cjs --out-dir lib",
+    "build": "tsup ./src/index.ts --format esm,cjs --out-dir lib --dts",
     "compile": "tsc",
     "coverage": "npm run test -- --coverage",
     "prepublishOnly": "npm run coverage",
@@ -49,6 +49,7 @@
       "require": "./lib/index.cjs"
     }
   },
+  "types": "./lib/index.d.ts",
   "main": "./lib/index.js",
   "license": "MIT",
   "type": "module"


### PR DESCRIPTION
Hi !

Since the NPM [@types/node-emoji](https://www.npmjs.com/package/@types/node-emoji) package is not aligned with version 2.0 of [node-emoji](https://www.npmjs.com/package/node-emoji), I suggest exporting the TypeScript types directly in this package, and therefore managing the types in this repo, rather than in [DefinitelyTyped](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/node-emoji).