### PR TITLE
build: generate typescript definition files

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "typescript": "^5.0.4"
   },
   "scripts": {
-    "build": "tsup ./src/index.ts --format esm,cjs --out-dir lib",
+    "build": "tsup ./src/index.ts --format esm,cjs --out-dir lib --dts",
     "compile": "tsc",
     "coverage": "npm run test -- --coverage",
     "prepublishOnly": "npm run coverage",


### PR DESCRIPTION
Adds `--dts` flag to `tsup` to generate TypeScript type definition files as part of the build process.

When I upgraded to v2 I got TypeScript errors because there where no type definitions so this
PR adds to the `--dts` flag so `.d.ts` files are generated in the final output.