### PR TITLE
fix: pin skin-tone to ^2.0.0 and add renovate.json ignoreDeps

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "automerge": true,
+  "ignoreDeps": ["@sindresorhus/is", "char-regex", "emojilib", "skin-tone"],
   "internalChecksFilter": "strict",
   "labels": ["dependencies"],
   "minimumReleaseAge": "3 days",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "@sindresorhus/is": "^4.6.0",
     "char-regex": "^1.0.2",
     "emojilib": "^2.4.0",
-    "skin-tone": "^3.0.0"
+    "skin-tone": "^2.0.0"
   },
   "devDependencies": {
     "@release-it/conventional-changelog": "^8.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ dependencies:
     specifier: ^2.4.0
     version: 2.4.0
   skin-tone:
-    specifier: ^3.0.0
-    version: 3.0.0
+    specifier: ^2.0.0
+    version: 2.0.0
 
 devDependencies:
   '@release-it/conventional-changelog':
@@ -6446,9 +6446,9 @@ packages:
     engines: {node: '>=14'}
     dev: true
 
-  /skin-tone@3.0.0:
-    resolution: {integrity: sha512-+HTlUiUJr3SjmOiKV3dPeGWcl7dgqv09OgFWJxD26vOmYss7DWKCl6sqHEjM1hddov/vXQN2bOKIMr0DMUJVSQ==}
-    engines: {node: '>=12'}
+  /skin-tone@2.0.0:
+    resolution: {integrity: sha512-kUMbT1oBJCpgrnKoSr0o6wPtvRWT9W9UKvGLwfJYO2WuahZRHOpEyL1ckyMGgMWh0UdpmaoFqKKD29WTomNEGA==}
+    engines: {node: '>=8'}
     dependencies:
       unicode-emoji-modifier-base: 1.0.0
     dev: false


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #153 (again)
- [x] That issue was marked as [`status: accepting prs`](https://github.com/omnidan/node-emoji/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/omnidan/node-emoji/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Continues #154 by pinning the last ESM-only dependency, `skin-tone`, to its pre-#142 version. See https://github.com/omnidan/node-emoji/issues/153#issuecomment-1819534057.

I don't know why the CJS test from #154 passed with `skin-tone` (exports oddity? race condition?) so manually disables the ESM-only `dependencies` in `renove.json`. Which is ... most of them.