### PR TITLE
chore: remove rennovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,3 @@
+{
+  "enabled": false
+}

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,9 +1,0 @@
-{
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "automerge": true,
-  "ignoreDeps": ["@sindresorhus/is", "char-regex", "emojilib", "skin-tone"],
-  "internalChecksFilter": "strict",
-  "labels": ["dependencies"],
-  "minimumReleaseAge": "3 days",
-  "postUpdateOptions": ["pnpmDedupe"]
-}


### PR DESCRIPTION
I have received hundreds of dependency emails for this repository alone.
I don't think it is useful because most updates change the lockfile, but the lockfile is never published on npm.

The alternative to removing rennovate is to restrict it to only recommend updates to dependencies in `package.json`, or only security critical dependencies.